### PR TITLE
Replace CryptoKit with SwiftCrypto

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,14 +2,14 @@ name: test
 on:
 - pull_request
 jobs:
-  leaf_xenial:
+  test_xenial:
     container: 
       image: vapor/swift:5.2-xenial
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - run: swift test --enable-test-discovery --sanitize=thread
-  leaf_bionic:
+  test_bionic:
     container: 
       image: vapor/swift:5.2-bionic
     runs-on: ubuntu-latest

--- a/Package.swift
+++ b/Package.swift
@@ -12,10 +12,12 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0"),
     ],
     targets: [
         .target(name: "TelemetryDeck", dependencies: [
             .product(name: "Vapor", package: "vapor"),
+            .product(name: "Crypto", package: "swift-crypto"),
         ]),
         .testTarget(name: "TelemetryDeckTests", dependencies: [
             .target(name: "TelemetryDeck"),

--- a/Sources/TelemetryDeck/Application+Telemetry.swift
+++ b/Sources/TelemetryDeck/Application+Telemetry.swift
@@ -108,12 +108,13 @@ public extension Application {
         }
         
         final class Storage {
-            var baseURL: URL = .init(string: "https://nom.telemetrydeck.com/")!
+            var baseURL: URL
             var appID: UUID?
             var defaultParameters: [String: String] = [:]
             var sessionUUID: UUID = .init()
 
             init() {
+                baseURL = URL(string: "https://nom.telemetrydeck.com/")!
                 defaultParameters = [:]
             }
         }

--- a/Sources/TelemetryDeck/String+SHA256.swift
+++ b/Sources/TelemetryDeck/String+SHA256.swift
@@ -1,4 +1,4 @@
-import CryptoKit
+import Crypto
 import Foundation
 
 extension String {


### PR DESCRIPTION
## Why

CryptoKit is not supported on Linux builds, which leads to `vapor-telemetrydeck` not being compatible with deployments onto Linux platforms.

As Linux deployments are common, and a desired platform for us to support, this dependency replacement is necessary.

## Benefit

Our package will now support Linux.

## How

SwiftCrypto is a drop-in replacement for CryptoKit, maintained by Apple themselves and recommended by Vapor.