### PR TITLE
[td] log error instead of throwing

### DIFF
--- a/Sources/TelemetryDeck/Application+Telemetry.swift
+++ b/Sources/TelemetryDeck/Application+Telemetry.swift
@@ -25,8 +25,11 @@ public extension Application {
             additionalPayload: [String: String] = [:]
         ) -> EventLoopFuture<ClientResponse> {
             guard let appID = storage.appID else {
-                return application.eventLoopGroup.next()
-                    .future(error: TelemetryDeckError.notInitialised)
+                application.logger.error(
+                    "failed to send TelemetryDeck signal - library not initialised",
+                    metadata: ["signal": .string(signalType)]
+                )
+                return application.eventLoopGroup.next().future(ClientResponse())
             }
             
             var payload: [String: String] = [:]

--- a/Sources/TelemetryDeck/Models.swift
+++ b/Sources/TelemetryDeck/Models.swift
@@ -9,10 +9,6 @@ public struct TelemetryDeckConfiguration {
     public let apiBaseURL: URL
 }
 
-public enum TelemetryDeckError: Error {
-    case notInitialised
-}
-
 internal struct SignalPostBody: Codable, Equatable {
     /// When was this signal generated
     let receivedAt: Date


### PR DESCRIPTION
In clients whom intentionally decide to not initialise TelemetryDeck (for example on non-produciton environments, unit tests, etc), they would have to add a wrapper around all the interactions in order to avoid a situation which would throw 500s when used in requests.

This wasn't intentional, and the error didn't seem relevant enough to warrant a reaction by the client. If you've not registered - it's probably for a reason.

So we've replaced it with a log instead. May consider making it a one-off, will consider options.