### PR TITLE
Allow sending numerical values

### DIFF
--- a/Sources/TelemetryDeck/Application+Telemetry.swift
+++ b/Sources/TelemetryDeck/Application+Telemetry.swift
@@ -22,6 +22,7 @@ public extension Application {
         public func send(
             _ signalType: String,
             for clientUser: String? = nil,
+            floatValue: Double? = nil,
             additionalPayload: [String: String] = [:]
         ) -> EventLoopFuture<ClientResponse> {
             guard let appID = storage.appID else {
@@ -35,7 +36,7 @@ public extension Application {
             var payload: [String: String] = [:]
             payload = payload.merging(defaultParameters, uniquingKeysWith: { _, last in last })
             payload = payload.merging(additionalPayload, uniquingKeysWith: { _, last in last })
-            payload["telemetryClientVersion"] = "VaporTelemetryDeck 1.0.0"
+            payload["telemetryClientVersion"] = "VaporTelemetryDeck 1.1.0"
             
             let encodedPayload: [String] = payload.map { key, value in
                 key.replacingOccurrences(of: ":", with: "_") + ":" + value
@@ -55,8 +56,11 @@ public extension Application {
                 type: signalType,
                 payload: encodedPayload,
                 
+                
                 // We will mark the signal as being in "test mode" if the environment is not production.
-                isTestMode: application.environment.isRelease ? "false" : "true"
+                isTestMode: application.environment.isRelease ? "false" : "true",
+                
+                floatValue: floatValue
             )
             
             let uri = URI(string: storage.baseURL.absoluteString.finished(with: "/")
@@ -81,9 +85,10 @@ public extension Application {
         public func send(
             _ signalType: String,
             for clientUser: String? = nil,
+            floatValue: Double? = nil,
             additionalPayload: [String: String] = [:]
         ) async throws -> ClientResponse {
-            try await send(signalType, for: clientUser, additionalPayload: additionalPayload).get()
+            try await send(signalType, for: clientUser, floatValue: floatValue, additionalPayload: additionalPayload).get()
         }
         #endif
         

--- a/Sources/TelemetryDeck/Models.swift
+++ b/Sources/TelemetryDeck/Models.swift
@@ -31,4 +31,7 @@ internal struct SignalPostBody: Codable, Equatable {
 
     /// If "true", mark the signal as a testing signal and only show it in a dedicated test mode UI
     let isTestMode: String
+    
+    /// An optional numerical value that can be used as a basis for aggregation, averages, etc.
+    let floatValue: Double?
 }

--- a/Sources/TelemetryDeck/Request+Telemetry.swift
+++ b/Sources/TelemetryDeck/Request+Telemetry.swift
@@ -9,7 +9,7 @@ public extension Request {
         public let application: Application
         public let request: Request
         
-        public func send(_ signalType: String, additionalPayload: [String: String] = [:]) -> EventLoopFuture<ClientResponse> {
+        public func send(_ signalType: String, floatValue: Double? = nil, additionalPayload: [String: String] = [:]) -> EventLoopFuture<ClientResponse> {
             // The XFF header may sometimes be comma-separated (this has been proven to be true on Google Cloud services).
             //
             // The header will include the client IP address first, followed by a number of proxy services such as load
@@ -24,14 +24,15 @@ public extension Request {
             return application.telemetryDeck.send(
                 signalType,
                 for: userIdentifier,
+                floatValue: floatValue,
                 additionalPayload: additionalPayload
             )
         }
         
         #if compiler(>=5.5) && canImport(_Concurrency)
         @discardableResult
-        public func send(_ signalType: String, additionalPayload: [String: String] = [:]) async throws -> ClientResponse {
-            try await send(signalType, additionalPayload: additionalPayload).get()
+        public func send(_ signalType: String, floatValue: Double? = nil, additionalPayload: [String: String] = [:]) async throws -> ClientResponse {
+            try await send(signalType, floatValue: floatValue, additionalPayload: additionalPayload).get()
         }
         #endif
     }

--- a/Tests/TelemetryDeckTests/TelemetryDeckTests.swift
+++ b/Tests/TelemetryDeckTests/TelemetryDeckTests.swift
@@ -46,7 +46,7 @@ class TelemetryDeckTests: XCTestCase {
         
         let signal = try getFirstSignal(from: app)
         XCTAssertEqual(signal.appID.uuidString, testID)
-        XCTAssertEqual(signal.payload, ["telemetryClientVersion:VaporTelemetryDeck 1.0.0"])
+        XCTAssertEqual(signal.payload, ["telemetryClientVersion:VaporTelemetryDeck 1.1.0"])
         XCTAssertEqual(signal.isTestMode, "true")
         XCTAssertEqual(signal.clientUser, "vapor")
         XCTAssertEqual(signal.type, "signal")
@@ -77,7 +77,7 @@ class TelemetryDeckTests: XCTestCase {
         
         let signal = try getFirstSignal(from: app)
         XCTAssertEqual(signal.appID.uuidString, testID)
-        XCTAssertEqual(signal.payload, ["telemetryClientVersion:VaporTelemetryDeck 1.0.0"])
+        XCTAssertEqual(signal.payload, ["telemetryClientVersion:VaporTelemetryDeck 1.1.0"])
         XCTAssertEqual(signal.isTestMode, "true")
         XCTAssertEqual(signal.clientUser, "49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d9763")
         XCTAssertEqual(signal.type, "signal")
@@ -105,7 +105,7 @@ class TelemetryDeckTests: XCTestCase {
         XCTAssertEqual(signal.payload.sorted(), [
             "key1:value1",
             "key2:value2",
-            "telemetryClientVersion:VaporTelemetryDeck 1.0.0",
+            "telemetryClientVersion:VaporTelemetryDeck 1.1.0",
         ])
     }
     
@@ -131,7 +131,7 @@ class TelemetryDeckTests: XCTestCase {
         XCTAssertEqual(signal.payload.sorted(), [
             "default:true",
             "function:true",
-            "telemetryClientVersion:VaporTelemetryDeck 1.0.0",
+            "telemetryClientVersion:VaporTelemetryDeck 1.1.0",
         ])
     }
     


### PR DESCRIPTION
The TelemetryDeck Ingestion API now supports numerical float values. This PR adds that ability to the Vapor Client. It's super handy for e.g. sending request duration in a middleware.